### PR TITLE
URL to docs for audio desc fixed

### DIFF
--- a/src/data/code-samples/en/media-audio-description/react-native.md
+++ b/src/data/code-samples/en/media-audio-description/react-native.md
@@ -1,6 +1,6 @@
 # Audio description - React Native
 
-On React Native, the [React-Native-Video](https://github.com/react-native-video/react-native-video) package has support for [switching audio tracks](https://github.com/react-native-video/react-native-video/blob/master/API.md#selectedaudiotrack). This allows you to offer users a way to switch to an audio description track.
+On React Native, the [React-Native-Video](https://github.com/react-native-video/react-native-video) package has support for [switching audio tracks](https://thewidlarzgroup.github.io/react-native-video/component/props#selectedaudiotrack). This allows you to offer users a way to switch to an audio description track.
 
 Note: The audio tracks must be encoded in the file, this is not something you add programmatically.
 


### PR DESCRIPTION
Old one was 404

# What does this PR do?

Old link was not working, I've replaced it with working link
Just fixing the URL in the documentation

## How do you test this PR?

Open the old link - it will return 404, check the new link, it should work

Test steps:

N.A.

## Checklist

Does not impact anything else.

## Accessibility checklist

Does not impact anything else, accessibility name stays the same as it is still the same destination.
