### PR TITLE
Updated docs url for texttracks in react native video

### DIFF
--- a/src/data/code-samples/en/media-captions/react-native.md
+++ b/src/data/code-samples/en/media-captions/react-native.md
@@ -1,6 +1,6 @@
 # Captions - React Native
 
-In React Native, you can use the [React-Native-Video](https://github.com/react-native-video/react-native-video/blob/master/API.md#texttracks) package to add captions in `.vtt`, `.ttml` and `.srt` formats. It is advised to use `.vtt` as it is supported on both Android and iOS.
+In React Native, you can use the [React-Native-Video](https://thewidlarzgroup.github.io/react-native-video/component/props#texttracks) package to add captions in `.vtt`, `.ttml` and `.srt` formats. It is advised to use `.vtt` as it is supported on both Android and iOS.
 
 ```jsx
 import { TextTrackType, Video } from 'react-native-video';


### PR DESCRIPTION
# What does this PR do?

Fixes url that is 404 now.

## How do you test this PR?

Old url will return 404 not found, new url will work well

Test steps:

N.A.

## Checklist

Does not change anything...

## Accessibility checklist

Does not change anything, I've also left the link name as it was before...
